### PR TITLE
Pin the supported Ubuntu version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Kudos to DOROWU for his amazing VNC 16.04 KDE image
-FROM dorowu/ubuntu-desktop-lxde-vnc
+FROM dorowu/ubuntu-desktop-lxde-vnc:bionic
 LABEL maintainer "bpinaya@wpi.edu"
 
 RUN apt-get update && apt-get install -y dirmngr


### PR DESCRIPTION
It seems ros-melodic-desktop-full only exists under Ubuntu Bionic (18.04). I've pinned that tag of the base image.